### PR TITLE
Add shape drawing compatibility addon

### DIFF
--- a/src/shapes.js
+++ b/src/shapes.js
@@ -1,0 +1,55 @@
+function addShapes(p5, fn, lifecycles) {
+  const oldBezierVertex = fn.bezierVertex;
+
+  lifecycles.predraw = function() {
+    this.splineProperty('ends', this.EXCLUDE);
+  }
+
+  fn.quadraticVertex = function(...args) {
+    this.bezierOrder(2);
+    if (args.length === 4) {
+      const [x1, y1, x2, y2] = args;
+      oldBezierVertex.call(this, x1, y1);
+      oldBezierVertex.call(this, x2, y2);
+    } else if (args.length === 6) {
+      const [x1, y1, z1, x2, y2, z2] = args;
+      oldBezierVertex.call(this, x1, y1, z1);
+      oldBezierVertex.call(this, x2, y2, z2);
+    } else {
+      throw new Error(
+        `quadraticVertex() was expecting either 4 or 6 arguments, but it was called with ${args.length}.`
+      );
+    }
+  }
+
+  fn.bezierVertex = function(...args) {
+    this.bezierOrder(3);
+    if (args.length === 6) {
+      const [x1, y1, x2, y2, x3, y3] = args;
+      oldBezierVertex.call(this, x1, y1);
+      oldBezierVertex.call(this, x2, y2);
+      oldBezierVertex.call(this, x3, y3);
+    } else if (args.length === 9) {
+      const [x1, y1, z1, x2, y2, z2, x3, y3, z3] = args;
+      oldBezierVertex.call(this, x1, y1, z1);
+      oldBezierVertex.call(this, x2, y2, z2);
+      oldBezierVertex.call(this, x3, y3, z3);
+    } else {
+      throw new Error(
+        `bezierVertex() was expecting either 6 or 9 arguments, but it was called with ${args.length}.`
+      );
+    }
+  }
+
+  fn.curveVertex = function(...args) {
+    return this.splineVertex(...args);
+  }
+
+  fn.curveTightness = function(value) {
+    return this.splineProperty('tightness', value);
+  }
+}
+
+if (typeof p5 !== undefined) {
+  p5.registerAddon(addShapes);
+}


### PR DESCRIPTION
Demo: https://editor.p5js.org/davepagurek/sketches/3GbcH6Am3

Changes:
- Restores old behaviour of `bezierVertex`
- Restores old `quadraticVertex` function
- Aliases the new `splineVertex` to the old `curveVertex`
- Aliases the new `splineProperty('tightness', t)` to the old `curveTightness(t)`
- Sets the default `splineProperty('ends')` from `INCLUDE`, the new default, to `EXCLUDE`, the default in 1.x