### PR TITLE
Shape updates

### DIFF
--- a/src/shapes.js
+++ b/src/shapes.js
@@ -59,6 +59,10 @@ function addShapes(p5, fn, lifecycles) {
     this._renderer._currentShape.at(-1, -1).handlesClose = () => false;
     oldEndShape.call(this, mode);
   }
+
+  fn.curve = function(...args) {
+    return this.spline(...args);
+  }
 }
 
 if (typeof p5 !== undefined) {

--- a/src/shapes.js
+++ b/src/shapes.js
@@ -2,6 +2,7 @@ function addShapes(p5, fn, lifecycles) {
   const oldBezierVertex = fn.bezierVertex;
   const oldEndContour = fn.endContour;
   const oldEndShape = fn.endShape;
+  const oldCurveDetail = fn.curveDetail;
 
   lifecycles.predraw = function() {
     this.splineProperty('ends', this.EXCLUDE);
@@ -69,6 +70,22 @@ function addShapes(p5, fn, lifecycles) {
   }
   fn.endGeometry = function(...args) {
     return this._renderer.endGeometry(...args);
+  }
+
+  for (const key of ['curveDetail', 'bezierDetail']) {
+    fn[key] = function(numPoints) {
+      // p5 2.0's curveDetail defined *density* while 1.x's defined *absolute number of points.*
+      // The only way to do a true conversion would involve updating the value dynamically based
+      // on the length of the curve. Since this would be complex to do as an addon, we do
+      // the calculation based on an approximate average curve length.
+      const avgLength = Math.hypot(this.width, this.height) / 3;
+      if (numPoints) {
+        const density = numPoints / avgLength;
+        return oldCurveDetail.call(this, density); 
+      } else {
+        return oldCurveDetail.call(this) * avgLength;
+      }
+    }
   }
 }
 

--- a/src/shapes.js
+++ b/src/shapes.js
@@ -63,6 +63,13 @@ function addShapes(p5, fn, lifecycles) {
   fn.curve = function(...args) {
     return this.spline(...args);
   }
+
+  fn.beginGeometry = function(...args) {
+    return this._renderer.beginGeometry(...args);
+  }
+  fn.endGeometry = function(...args) {
+    return this._renderer.endGeometry(...args);
+  }
 }
 
 if (typeof p5 !== undefined) {


### PR DESCRIPTION
Some implementations previously missing, brought up again by @GregStanton here: https://github.com/processing/p5.js-compatibility/issues/1#issuecomment-2743493721

- Maps the old `curve()` to the new `spline()` (changed in https://github.com/processing/p5.js/pull/7656)
- Puts back public `beginGeometry`/`endGeometry` methods (hidden in favor of `buildGeometry` for API clarity; they still exist internally in the renderer as part of the internal implementation, so we can just expose them again here)
- Adds an approximate mapping of the old `curveDetail` and `bezierDetail` to the new `curveDetail`. It's not super feasible in an addon to fully restore the old behaviour fully, so this has the following compromises:
  - It sets the sampling density based on an assumed average curve length, since we can't easily access the actual length of each curve. I'm using a third of the diagonal of the canvas size.
  - There's still only one detail under the hood; code that tries to use two separate details (which at least seems uncommon in practice) will end up overwriting the same singular detail