### PR TITLE
Put back curvePoint/Tangent

### DIFF
--- a/src/shapes.js
+++ b/src/shapes.js
@@ -87,6 +87,13 @@ function addShapes(p5, fn, lifecycles) {
       }
     }
   }
+
+  fn.curvePoint = function(...args) {
+    return this.splinePoint(...args);
+  }
+  fn.curveTangent = function(...args) {
+    return this.splineTangent(...args);
+  }
 }
 
 if (typeof p5 !== undefined) {


### PR DESCRIPTION
Adds back support for `curvePoint` and `curveTangent` after removing them here: https://github.com/processing/p5.js/pull/7703