### PR TITLE
Add p5.Element touch events

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -9,41 +9,17 @@ function addData(p5, fn){
     return this.mouseDragged(...args);
   };
   p5.Element.prototype.touchStarted = function (cb) {
-    if (cb === false) {
-      return this.mousePressed(false);
-    }
-    return this.mousePressed(function (event) {
-      if (this._hasTouchMoveHandler) {
-        this._pointers = this._pointers || {};
-        this._pointers[event.pointerId] = true;
-      }
-      event.target.setPointerCapture(event.pointerId);
-      return cb(event);
-    });
+    return this.mousePressed(cb);
   };
   p5.Element.prototype.touchEnded = function (cb) {
-    if (cb === false) {
-      return this.mouseReleased(false);
-    }
-    return this.mouseReleased(function (event) {
-      if (this._hasTouchMoveHandler) {
-        this._pointers = this._pointers || {};
-        if (this._pointers[event.pointerId]) {
-          event.target.releasePointerCapture(event.pointerId);
-          delete this._pointers[event.pointerId];
-        }
-      }
-      return cb(event);
-    });
+    return this.mouseReleased(cb);
   };
   p5.Element.prototype.touchMoved = function (cb) {
     if (cb === false) {
-      this._hasTouchMoveHandler = false;
       return this.mouseMoved(false);
     }
-    this._hasTouchMoveHandler = true;
     return this.mouseMoved(function (event) {
-      if (Object.keys(this._pointers || {}).length > 0) {
+      if ((event.buttons & 1) !== 0) {
         return cb(event);
       }
     });

--- a/src/data.js
+++ b/src/data.js
@@ -8,6 +8,46 @@ function addData(p5, fn){
   fn.touchMoved = function (...args) {
     return this.mouseDragged(...args);
   };
+  p5.Element.prototype.touchStarted = function (cb) {
+    if (cb === false) {
+      return this.mousePressed(false);
+    }
+    return this.mousePressed(function (event) {
+      if (this._hasTouchMoveHandler) {
+        this._pointers = this._pointers || {};
+        this._pointers[event.pointerId] = true;
+      }
+      event.target.setPointerCapture(event.pointerId);
+      return cb(event);
+    });
+  };
+  p5.Element.prototype.touchEnded = function (cb) {
+    if (cb === false) {
+      return this.mouseReleased(false);
+    }
+    return this.mouseReleased(function (event) {
+      if (this._hasTouchMoveHandler) {
+        this._pointers = this._pointers || {};
+        if (this._pointers[event.pointerId]) {
+          event.target.releasePointerCapture(event.pointerId);
+          delete this._pointers[event.pointerId];
+        }
+      }
+      return cb(event);
+    });
+  };
+  p5.Element.prototype.touchMoved = function (cb) {
+    if (cb === false) {
+      this._hasTouchMoveHandler = false;
+      return this.mouseMoved(false);
+    }
+    this._hasTouchMoveHandler = true;
+    return this.mouseMoved(function (event) {
+      if (Object.keys(this._pointers || {}).length > 0) {
+        return cb(event);
+      }
+    });
+  };
 
   fn.append = function (array, value) {
     array.push(value);


### PR DESCRIPTION
Resolves #21 

This is a little more involved due to the existence of `touchMoved` in 1.x, which acts like a drag listener. We don't have a pointer event just for drag; instead, we have to use a move event, and filter out cases where the button isn't down.

Live: https://editor.p5js.org/davepagurek/sketches/nR6KyY9vF